### PR TITLE
Collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.csv
+data/
 env/
 *.csv
 __pycache__/

--- a/app.py
+++ b/app.py
@@ -1,16 +1,24 @@
-from flask import Flask, request, render_template
+from flask import Flask, request, render_template, url_for, redirect
 import serial
 import peripherals
+import data_utils
+from pathlib import Path
 from datetime import datetime
 import RPi.GPIO as gpio
 import pandas as pd
+import multiprocessing
+import time
+import re
 
 app = Flask(__name__)
 PORT = '/dev/ttyACM0'
+DATA_BASE_DIR = 'data'
+FILE_PATTERN = 'growbox_data_(sensor|fake)_(?P<date>\d{8})-(?P<hour>\d{1,2})\.csv'
 
 RELAY = 21
 gpio.setmode(gpio.BCM)
 gpio.setup(RELAY, gpio.OUT)
+
 
 base = '''
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
@@ -33,18 +41,42 @@ function submit(which) {{
 # which is also set at 9600)
 arduino_comm = serial.Serial(PORT, 9600)
 
+collector = peripherals.Collector() 
+
 
 @app.route('/')
 def hello_world():
     return 'Hello, World!'
 
 
+@app.route('/stop')
+def stop_loop():
+    collector.stop()
+    return redirect(url_for('show_current_readings'))
+
+
+@app.route('/start')
+def start_collection():
+    collector.data_dir = request.args.get('data_dir', '.', type=str)
+    collector.sample_rate = request.args.get('sample_rate', 60, type=int)
+    collector.source = request.args.get('source', 'sensor', type=str)
+    collector.start()
+    return redirect(url_for('show_current_readings'))
+    
+
 @app.route('/current')
 def show_current_readings():
     print(request.url)
-    humidity, temp = peripherals.get_sensor_data(arduino_comm)
-    now = datetime.now()
-    return base.format(temp=temp, humidity=humidity, now=now)
+    current_data = peripherals.get_sensor_datapoint()
+    data = get_data()
+    return render_template(
+        'index.html',
+        temp=current_data.temp,
+        humidity=current_data.humidity,
+        now=current_data.time,
+        status=collector.status,
+        plotdata=data
+    )
 
 
 @app.route('/fancontrol', methods=['POST'])
@@ -57,19 +89,20 @@ def actuate_fan():
     return 'you got it'
 
 
-@app.route('/current_temperature')
-def get_current_temperature():
-    ...
-    return '5'
+# @app.route('/data/<data_dir>')
+def get_data(data_dir):
+	data_dir = Path(DATA_BASE_DIR) / data_dir
+	all_files =data_dir.glob('*.csv')
+	dfs = [pd.read_csv(f) for f in all_files if re.match(FILE_PATTERN, f.name)]
+	return pd.concat(dfs).to_json(orient='records')
 
-@app.route('/graph')
-def render_graph():
-    print(request.url)
-    file = 'testfile.csv'
-    df = pd.read_csv(file)
-    template = render_template('graph.html', data=df.to_json(orient='records'))
+
+@app.route('/graph/<collection_name>')
+def render_graph(collection_name):
+    data = data_utils.get_data(collection_name)
+    template = render_template('graph.html', data=data.to_json(orient='records'))
     return template
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000, host="0.0.0.0")
+    app.run(debug=True, port=28471, host="0.0.0.0", use_reloader=False)

--- a/app.py
+++ b/app.py
@@ -4,7 +4,6 @@ import peripherals
 import data_utils
 from pathlib import Path
 from datetime import datetime
-import RPi.GPIO as gpio
 import pandas as pd
 import multiprocessing
 import time
@@ -15,34 +14,7 @@ PORT = '/dev/ttyACM0'
 DATA_BASE_DIR = 'data'
 FILE_PATTERN = 'growbox_data_(sensor|fake)_(?P<date>\d{8})-(?P<hour>\d{1,2})\.csv'
 
-RELAY = 21
-gpio.setmode(gpio.BCM)
-gpio.setup(RELAY, gpio.OUT)
-
-
-base = '''
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-<h3>Reading at {now}</h3>
-<b>Temperature:</b> {temp} <br>
-<b>Humidity:</b> {humidity} <br>
-<div style="border: 2px solid green;width: 25%">
-    <input type="button" onclick="submit('on')" value="Fan on"/>
-    <input type="button" onclick="submit('off')" value="Fan off"/>
-
-<script>
-function submit(which) {{
-    console.log(which);
-    $.post("/fancontrol", {{"setButtonTo": which}})
-}}
-</script>
-'''
-
-# Instantiate Serial object with 9600 baud rate (to match Arduino,
-# which is also set at 9600)
-arduino_comm = serial.Serial(PORT, 9600)
-
-collector = peripherals.Collector() 
-
+collector = peripherals.Collector()
 
 @app.route('/')
 def hello_world():
@@ -68,14 +40,12 @@ def start_collection():
 def show_current_readings():
     print(request.url)
     current_data = peripherals.get_sensor_datapoint()
-    data = get_data()
     return render_template(
         'index.html',
         temp=current_data.temp,
         humidity=current_data.humidity,
         now=current_data.time,
         status=collector.status,
-        plotdata=data
     )
 
 
@@ -87,14 +57,6 @@ def actuate_fan():
     elif which == 'on':
         gpio.output(RELAY, gpio.LOW)
     return 'you got it'
-
-
-# @app.route('/data/<data_dir>')
-def get_data(data_dir):
-	data_dir = Path(DATA_BASE_DIR) / data_dir
-	all_files =data_dir.glob('*.csv')
-	dfs = [pd.read_csv(f) for f in all_files if re.match(FILE_PATTERN, f.name)]
-	return pd.concat(dfs).to_json(orient='records')
 
 
 @app.route('/graph/<collection_name>')

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, render_template, url_for, redirect
+from flask import Flask, request, render_template, url_for, redirect, jsonify
 import serial
 import peripherals
 import data_utils
@@ -45,6 +45,22 @@ def show_current_readings():
         status=collector.status,
         plotdata=data,
     )
+
+@app.route('/current')
+def get_current_readings():
+    current = peripherals.get_sensor_datapoint()
+    payload =  {
+        'temp': current.temp,
+        'humidity': current.humidity,
+        'time': current.time_nice
+    }
+    return jsonify(payload)
+
+
+@app.route('/collection')
+def get_collection_data():
+    data = data_utils.get_data(collector.data_dir).to_json(orient='records')
+    return jsonify(data)
 
 
 @app.route('/fancontrol', methods=['POST'])

--- a/app.py
+++ b/app.py
@@ -16,10 +16,6 @@ FILE_PATTERN = 'growbox_data_(sensor|fake)_(?P<date>\d{8})-(?P<hour>\d{1,2})\.cs
 
 collector = peripherals.Collector()
 
-@app.route('/')
-def hello_world():
-    return 'Hello, World!'
-
 
 @app.route('/stop')
 def stop_loop():
@@ -36,16 +32,18 @@ def start_collection():
     return redirect(url_for('show_current_readings'))
     
 
-@app.route('/current')
+@app.route('/')
 def show_current_readings():
     print(request.url)
     current_data = peripherals.get_sensor_datapoint()
+    data = data_utils.get_data(collector.data_dir).to_json(orient='records')
     return render_template(
         'index.html',
         temp=current_data.temp,
         humidity=current_data.humidity,
         now=current_data.time,
         status=collector.status,
+        plotdata=data,
     )
 
 

--- a/data_utils.py
+++ b/data_utils.py
@@ -2,6 +2,7 @@ import re
 import pandas as pd
 from pathlib import Path
 from datetime import datetime
+import numpy as np
 
 DATA_BASE_DIR = 'data'
 
@@ -25,4 +26,6 @@ def get_data(data_dir, start=None, end=None):
 	# 	condition = start is not None
 	# 	if start is not None and file_start >= start:
 	dfs = [pd.read_csv(f) for f in all_files if re.match(FILE_PATTERN, f.name)]
+	if not dfs:
+		return pd.DataFrame([{'time': np.nan, 'temp': np.nan, 'humidity': np.nan}])
 	return pd.concat(dfs).sort_values(by='time')

--- a/data_utils.py
+++ b/data_utils.py
@@ -1,0 +1,28 @@
+import re
+import pandas as pd
+from pathlib import Path
+from datetime import datetime
+
+DATA_BASE_DIR = 'data'
+
+FILE_PATTERN = 'growbox_data_(sensor|fake)_(?P<date>\d{8})-(?P<hour>\d{1,2})\.csv'
+
+def get_data(data_dir, start=None, end=None):
+	data_dir = Path(DATA_BASE_DIR) / data_dir
+	all_files =data_dir.glob('*.csv')
+	# Get files that fall within the date range
+	# files_in_range = []
+	# for file in Path(data_dir).glob('*.csv'):
+	# 	match = re.match(FILE_PATTERN, file.name)
+	# 	date = match['date']
+	# 	hour = match['hour']
+	# 	file_start = datetime(
+	# 		year=int(date[:4]),
+	# 		month=int(date[4:6]),
+	# 		day=int(date[6:]),
+	# 		hour=int(hour)
+	# 	)
+	# 	condition = start is not None
+	# 	if start is not None and file_start >= start:
+	dfs = [pd.read_csv(f) for f in all_files if re.match(FILE_PATTERN, f.name)]
+	return pd.concat(dfs).sort_values(by='time')

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,2 @@
+20211120: I had to call `git config core.filemode false` to tell git not to
+	  track changes to file permissions bits

--- a/peripherals.py
+++ b/peripherals.py
@@ -57,6 +57,10 @@ class DataPoint:
         self.minute = self._time.minute
         self.year = self._time.year
         self.month = self._time.month
+
+    @property
+    def time_nice(self):
+        return self._time.strftime('%Y-%m-%d %H:%M:%S')
     
     def __repr__(self):
         return f'{self.time},{self.humidity},{self.temp}'

--- a/peripherals.py
+++ b/peripherals.py
@@ -12,6 +12,7 @@ import numpy as np
 import serial
 import boto3
 import tqdm
+import RPi.GPIO as gpio
 
 DATA_BASE_DIR = 'data'
 BUCKET = 'nous-growbox'
@@ -22,6 +23,12 @@ HEADER = 'time,humidity,temp'
 # module is called or imported. The 2 second delay is to allow all of the serial 
 # 'handshaking' to initialize properly
 ARDUINO = serial.Serial(PORT, 9600)
+
+# Setup raspberry pi pins
+RELAY = 21
+gpio.setmode(gpio.BCM)
+gpio.setup(RELAY, gpio.OUT)
+
 print('Initializing serial port')
 time.sleep(2)
 

--- a/peripherals.py
+++ b/peripherals.py
@@ -65,16 +65,12 @@ def get_sensor_datapoint(serial=ARDUINO):
     time.sleep(0.5)
     s = serial.readline().strip().decode()
     humidity, temp = s.split(',')
-    return DataPoint(float(humidity), float(temp))
+    return DataPoint(float(temp), float(humidity))
 
     
 def capture_loop(sample_rate: int, source: str, data_dir='.'):
     while True:
-        try:
-            capture_single_point(source, data_dir)
-        except ValueError:  #TODO fix this nasty code
-            breakpoint()
-            continue
+        capture_single_point(source, data_dir)
         time.sleep(sample_rate)
 
 
@@ -125,16 +121,25 @@ class Collector:
 
     '''
     def __init__(self, data_dir='.', source='sensor', sample_rate=60):
-        self.is_running = False
+        self._is_running = False
         self.data_dir = data_dir
         self.source = source
         self.sample_rate = sample_rate 
 
         self._p = None  # Variable to hold a multiprocessing.Process instance
 
+
+    @property
+    def is_running(self):
+        return self._is_running
+
+    @is_running.setter
+    def is_running(self, status):
+        raise ValueError('Cannot set this property manually!')
+
     def start(self):
         '''Starts a new collection at one sample every <sample_rate> seconds.'''
-        if self.is_running:
+        if self._is_running:
             print(f'This process is already running')
 
         else:  # Create and start a new process
@@ -143,18 +148,18 @@ class Collector:
                 args=(self.sample_rate, self.source, self.data_dir)
             )
             self._p.start()
-            self.is_running=True
+            self._is_running=True
             print(f'Started a collection at {60/self.sample_rate} points per minute in {self.data_dir}')
 
 
     def stop(self):
         '''Stops the current process'''
-        if not self.is_running:
+        if not self._is_running:
             print('No currently running process')
         
         else:  # Stop the current process
             self._p.terminate()
-            self.is_running = False
+            self._is_running = False
             print(f'{self} stopped')
 
 

--- a/peripherals.py
+++ b/peripherals.py
@@ -1,15 +1,18 @@
-import time
+# Standard Library
 from datetime import datetime
-import fire
+import multiprocessing
+from random import random
 from pathlib import Path
+import time
+
+# Third party
+import fire
+import numpy as np
 import serial
 import boto3
 import tqdm
-from random import random
-import multiprocessing
 
-
-DATA_FILE = 'sensor_data_{date}'
+DATA_BASE_DIR = 'data'
 BUCKET = 'nous-growbox'
 PORT = '/dev/ttyACM0'
 HEADER = 'time,humidity,temp'
@@ -64,7 +67,10 @@ def get_sensor_datapoint(serial=ARDUINO):
     serial.write('getTempHumidity\n'.encode())
     time.sleep(0.5)
     s = serial.readline().strip().decode()
-    humidity, temp = s.split(',')
+    try:
+        humidity, temp = s.split(',')
+    except ValueError:
+        humidity, temp = (np.nan, np.nan)
     return DataPoint(float(temp), float(humidity))
 
     
@@ -82,7 +88,8 @@ def capture_single_point(source: str, data_dir='.'):
         data = get_fake_datapoint()
 
     fname = f'growbox_data_{source}_{data.year}{data.month}{data.day}-{data.hour}.csv'
-    data_dir = Path(data_dir)
+    data_dir = Path(DATA_BASE_DIR) / data_dir
+    breakpoint()
     if not data_dir.exists():
         data_dir.mkdir()
 

--- a/peripherals.py
+++ b/peripherals.py
@@ -89,7 +89,6 @@ def capture_single_point(source: str, data_dir='.'):
 
     fname = f'growbox_data_{source}_{data.year}{data.month}{data.day}-{data.hour}.csv'
     data_dir = Path(DATA_BASE_DIR) / data_dir
-    breakpoint()
     if not data_dir.exists():
         data_dir.mkdir()
 

--- a/peripherals.py
+++ b/peripherals.py
@@ -1,5 +1,6 @@
 # Standard Library
 from datetime import datetime
+import json
 import multiprocessing
 from random import random
 from pathlib import Path
@@ -135,6 +136,19 @@ class Collector:
         self._p = None  # Variable to hold a multiprocessing.Process instance
 
 
+    # Convenience for sending data to frontend without having to send the entire object
+    @property
+    def status(self):
+        '''Returns object state as json string'''
+        status =  {
+            'is_running': self._is_running,
+            'data_dir': self.data_dir,
+            'source': self.source,
+            'sample_rate': self.sample_rate
+        }
+        return json.dumps(status)
+
+
     @property
     def is_running(self):
         return self._is_running
@@ -142,6 +156,7 @@ class Collector:
     @is_running.setter
     def is_running(self, status):
         raise ValueError('Cannot set this property manually!')
+
 
     def start(self):
         '''Starts a new collection at one sample every <sample_rate> seconds.'''

--- a/static/graph.js
+++ b/static/graph.js
@@ -1,0 +1,36 @@
+function plot_sensor_data(data, element_id) {
+	console.log(data);
+	time = data.map(item => item.time);
+	temp = data.map(item => item.temp);
+	humidity = data.map(item => item.humidity);
+
+	var temp_trace = {
+		type: 'line',
+		x: time,
+		y: temp,
+		name: 'Temperature',
+        mode: 'lines+markers'
+	};
+
+	var humidity_trace = {
+		type: 'line',
+		x: time,
+		y: humidity,
+		name: 'Humidity',
+        mode: 'lines+markers',
+	};
+
+	var layout = {
+		// width: 600,
+		// height: 400,
+		title: 'Mushy Readings',
+        margin: {
+            t: 50, //top margin
+            l: 20, //left margin
+            r: 20, //right margin
+            b: 20 //bottom margin
+            }
+	};
+
+	Plotly.newPlot(element_id,[temp_trace, humidity_trace], layout);
+}

--- a/static/loader.css
+++ b/static/loader.css
@@ -1,0 +1,57 @@
+/* CSS for animated bouncing loader. 
+Inspired by source online:
+https://codepen.io/MaedahBatool/pen/wZxMjZ?editors=1100
+https://www.digitalocean.com/community/tutorials/create-a-bouncing-page-loader-with-css3-animations
+*/
+
+.loader {
+	display: flex;
+	justify-content: center;
+	      align-items: center;
+      }
+      
+      /* Loader circles */
+      .loader > span {
+	background: lightslategray;
+	border-radius: 50%;
+	margin: 0.2rem 0.2rem;
+	width: 1.5rem;
+	height: 1.5rem;
+	animation: bouncingLoader 8s infinite alternate;
+      }
+      
+      .loader > span:nth-child(2) {
+	animation-delay: 2.5;
+      }
+      
+      .loader > span:nth-child(3) {
+	animation-delay: 5;
+      }
+      
+      /* Define the animation called bouncingLoader. */
+      @keyframes bouncingLoader {
+	from {
+	  /* width: 0.1rem;
+	  height: 0.1rem; */
+	  opacity: 1;
+	  /* transform: translate3d(0); */
+	}
+	to {
+	  /* width: 1rem;
+	  height: 1rem; */
+	  opacity: 0.1;
+	  /* transform: translate3d(0, -1rem, 0); */
+	}
+      }
+      
+      /* OPTIONAL: Styles for the demo. */
+      /* body {
+	background: #2C294F;
+	padding: 2rem;
+      }
+      
+      p {
+	font: 1rem/1.45 "Operator Mono";
+	color: #A599E9;
+	text-align: center;
+      } */

--- a/static/loader.css
+++ b/static/loader.css
@@ -17,15 +17,15 @@ https://www.digitalocean.com/community/tutorials/create-a-bouncing-page-loader-w
 	margin: 0.2rem 0.2rem;
 	width: 1.5rem;
 	height: 1.5rem;
-	animation: bouncingLoader 8s infinite alternate;
+	animation: bouncingLoader 3s infinite alternate;
       }
       
       .loader > span:nth-child(2) {
-	animation-delay: 2.5;
+	animation-delay: 1;
       }
       
       .loader > span:nth-child(3) {
-	animation-delay: 5;
+	animation-delay: 2;
       }
       
       /* Define the animation called bouncingLoader. */

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,16 +45,12 @@
 		<div class="container">
 			<div class="row">
 				<div class="col-9">
-					<div class='data-readout'>
-						<h3>Reading at {{ now }}</h3>
-						<b>Temperature:</b> {{ temp }} <br>
-						<b>Humidity:</b> {{ humidity }} <br>
-					</div>
+					<div id="data-readout" class="data-readout"></div>
 				</div>
 				<div class="col-3">
 					<div id="controls" class="collector-submit">
 						<h3>Sensor Controller</h3>
-						<label for="fname">data directory: </label>
+						<label for="fname">collection name: </label>
 						<input type="text" id="data-dir-input" value="data"><br>
 						<label for="source-input">select source</label>
 						<select id="source-input" name="source">
@@ -70,17 +66,43 @@
 				</div>
 			</div>
 			<div class="row">
+				<p>Refresh page to update graph with data from current collection</p>
 				<div id='plotarea'></div>
 			</div>
 		</div>
 	</body>
 
 	<script>
-		var foobar = {{ plotdata|safe }};
+		var collectorStatus = JSON.parse({{ status|tojson }});
+
+		// Help from https://stackoverflow.com/questions/58663713/using-set-interval-and-fetch-in-a-function
+		function displayLoop(updateGraph=false){
+			id = setInterval(async function(){
+				const response = await fetch('/current');
+				const data = await response.json();
+				readings = `
+					<h3>Current readings:</h3>
+					<b>Time:</b> ${data.time} <br>
+					<b>Temperature:</b> ${data.temp} <br>
+					<b>Humidity:</b> ${data.humidity} <br>
+					`
+				document.getElementById('data-readout').innerHTML = readings;
+				if (updateGraph) {
+					var update = {
+							x:  [[data.time], [data.time]],
+							y: [[data.temp], [data.humidity]]
+						};
+					Plotly.extendTraces('plotarea', update, [0, 1])
+				}
+			}, 2000);     
+			return id;
+		}
+
+
 		plot_sensor_data({{ plotdata|safe }}, 'plotarea');
 
+		var displayId = displayLoop();
 
-		var collectorStatus = JSON.parse({{ status|tojson }});
 		var data_dir_element = document.getElementById('data-dir-input');
 		var source_element = document.getElementById('source-input');
 		var sample_rate_element = document.getElementById('sample-rate-input');
@@ -131,10 +153,6 @@
 			<span></span>
 			`
 			loader.innerHTML = is_running ? loaderhtml : ''
-		}
-
-		function make_plot(data) {
-			a = 5;
 		}
 
 	</script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,19 +4,27 @@
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 		<link rel="stylesheet" href="{{ url_for('static', filename='loader.css') }}">
 
+		<!-- Bootstrap -->
+		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
 		<!-- Plotly -->
-			<script src="https://cdn.plot.ly/plotly-2.4.2.min.js"></script>
+		<script src="https://cdn.plot.ly/plotly-2.4.2.min.js"></script>
+		<!-- Our plotting code -->
+		<script src="{{ url_for('static', filename='graph.js') }}"></script>
+
+
 
 	<style>
 		.data-readout {
 			border: 1px solid black;
-			width: 170px;
 			padding: 10px;
 		}
 		.collector-submit {
 			border: 1px solid black;
-			width: 170px;
-			padding: 10px
+			width: auto;
+			padding: 10px;
+		}
+		.plotarea {
+			width: auto;
 		}
 		#start-button {
 			background-color: lightgreen;
@@ -33,30 +41,45 @@
 	</style>
 	</head>
 	<body>
-		<div class='data-readout'>
-			<h3>Reading at {{ now }}</h3>
-			<b>Temperature:</b> {{ temp }} <br>
-			<b>Humidity:</b> {{ humidity }} <br>
-		</div>
 		<br>
-
-		<div id="controls" class="collector-submit">
-			<label for="fname">data directory: </label>
-			<input type="text" id="data-dir-input" value="data"><br>
-			<label for="source-input">select source</label>
-			<select id="source-input" name="source">
-				<option value="sensor">sensor</option>
-				<option value="fake">synthetic</option>
-			</select>
-			<label for="lname">sample rate: </label>
-			<input type="text" id="sample-rate-input" value="60"><br>
-			<button id="start-button" onclick="start()">Start</button>
-			<button id="stop-button" onclick="stop()" disabled=true>Stop</button>
-			<div id="loader" class="loader"></div>
+		<div class="container">
+			<div class="row">
+				<div class="col-9">
+					<div class='data-readout'>
+						<h3>Reading at {{ now }}</h3>
+						<b>Temperature:</b> {{ temp }} <br>
+						<b>Humidity:</b> {{ humidity }} <br>
+					</div>
+				</div>
+				<div class="col-3">
+					<div id="controls" class="collector-submit">
+						<h3>Sensor Controller</h3>
+						<label for="fname">data directory: </label>
+						<input type="text" id="data-dir-input" value="data"><br>
+						<label for="source-input">select source</label>
+						<select id="source-input" name="source">
+							<option value="sensor">sensor</option>
+							<option value="fake">synthetic</option>
+						</select>
+						<label for="lname">sample rate: </label>
+						<input type="text" id="sample-rate-input" value="60"><br>
+						<button id="start-button" onclick="start()">Start</button>
+						<button id="stop-button" onclick="stop()" disabled=true>Stop</button>
+						<div id="loader" class="loader"></div>
+					</div>
+				</div>
+			</div>
+			<div class="row">
+				<div id='plotarea'></div>
+			</div>
 		</div>
 	</body>
 
 	<script>
+		var foobar = {{ plotdata|safe }};
+		plot_sensor_data({{ plotdata|safe }}, 'plotarea');
+
+
 		var collectorStatus = JSON.parse({{ status|tojson }});
 		var data_dir_element = document.getElementById('data-dir-input');
 		var source_element = document.getElementById('source-input');

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,14 +1,61 @@
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-<h3>Reading at {now}</h3>
-<b>Temperature:</b> {temp} <br>
-<b>Humidity:</b> {humidity} <br>
-<div style="border: 2px solid green;width: 25%">
-    <input type="button" onclick="submit('on')" value="Fan on"/>
-    <input type="button" onclick="submit('off')" value="Fan off"/>
+<!DOCTYPE html>
+<html>
+	<head>
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+	<style>
+		.data-readout {
+			border: 1px solid black;
+			width: 170px;
+			padding: 10px;
+		}
+		.collector-submit {
+			border: 1px solid black;
+			width: 170px;
+			padding: 10px
+		}
+	</style>
+	</head>
+	<body>
+		<div class='data-readout'>
+			<h3>Reading at {{ now }}</h3>
+			<b>Temperature:</b> {{ temp }} <br>
+			<b>Humidity:</b> {{ humidity }} <br>
+		</div>
+		<br>
 
-<script>
-function submit(which) {{
-    console.log(which);
-    $.post("/fancontrol", {{"setButtonTo": which}})
-}}
-</script>
+		<div class='collector-submit'>
+			<label for="fname">data_dir: </label>
+			<input type="text" id="data-dir-input" value="data"><br>
+			<label for="lname">source: </label>
+			<input type="text" id="source-input" value="sensor"><br>
+			<label for="lname">sample_rate: </label>
+			<input type="text" id="sample-rate-input" value="60"><br>
+			<input type="submit" value="Submit">
+			<button id="start-button" onclick="start()">Start</button>
+			<button id="stop-button" onclick="stop()" disabled=true>Stop</button>
+
+		</div>
+
+	</body>
+	<script>
+			var data_dir = document.getElementById('data-dir-input');
+			var source = document.getElementById('source-input');
+			var sample_rate = document.getElementById('sample-rate-input');
+			var stop_button = document.getElementById('stop-button');
+			var start_button = document.getElementById('start-button');
+
+		function start() {
+			stop_button.disabled = false;
+			start_button.disabled = true;
+			url = `/start?data_dir=${data_dir.value}&source=${source.value}&sample_rate=${sample_rate.value}`;
+			window.location.href = url
+
+		}
+
+		function stop() {
+			start_button.disabled = false;
+			stop_button.disabled = true;
+			window.location.href = `/stop`
+		}
+	</script>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -52,12 +52,7 @@
 			<input type="text" id="sample-rate-input" value="60"><br>
 			<button id="start-button" onclick="start()">Start</button>
 			<button id="stop-button" onclick="stop()" disabled=true>Stop</button>
-
-			<!-- <div class="loader">
-				<span></span>
-				<span></span>
-				<span></span> -->
-			</div>
+			<div id="loader" class="loader"></div>
 		</div>
 	</body>
 
@@ -71,6 +66,8 @@
 
 		var stop_button = document.getElementById('stop-button');
 		var start_button = document.getElementById('start-button');
+
+		var loader = document.getElementById('loader');
 
 		update_form();
 
@@ -102,6 +99,15 @@
 			data_dir_element.value = collectorStatus.data_dir;
 			source_element.value =  collectorStatus.source;
 			sample_rate_element.value = collectorStatus.sample_rate;
+
+			loaderhtml = `
+			<span></span>
+			<span></span>
+			<span></span>
+			<span></span>
+			<span></span>
+			`
+			loader.innerHTML = is_running ? loaderhtml : ''
 		}
 
 		function make_plot(data) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,11 @@
 <html>
 	<head>
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+		<link rel="stylesheet" href="{{ url_for('static', filename='loader.css') }}">
+
+		<!-- Plotly -->
+			<script src="https://cdn.plot.ly/plotly-2.4.2.min.js"></script>
+
 	<style>
 		.data-readout {
 			border: 1px solid black;
@@ -13,6 +18,18 @@
 			width: 170px;
 			padding: 10px
 		}
+		#start-button {
+			background-color: lightgreen;
+			width: 75px;
+			height: 55px;
+			border-radius: 10%;
+		}
+		#stop-button {
+			background-color: lightcoral;
+			width: 75px;
+			height: 55px;
+			border-radius: 10%;
+		}
 	</style>
 	</head>
 	<body>
@@ -23,39 +40,73 @@
 		</div>
 		<br>
 
-		<div class='collector-submit'>
-			<label for="fname">data_dir: </label>
+		<div id="controls" class="collector-submit">
+			<label for="fname">data directory: </label>
 			<input type="text" id="data-dir-input" value="data"><br>
-			<label for="lname">source: </label>
-			<input type="text" id="source-input" value="sensor"><br>
-			<label for="lname">sample_rate: </label>
+			<label for="source-input">select source</label>
+			<select id="source-input" name="source">
+				<option value="sensor">sensor</option>
+				<option value="fake">synthetic</option>
+			</select>
+			<label for="lname">sample rate: </label>
 			<input type="text" id="sample-rate-input" value="60"><br>
-			<input type="submit" value="Submit">
 			<button id="start-button" onclick="start()">Start</button>
 			<button id="stop-button" onclick="stop()" disabled=true>Stop</button>
 
+			<!-- <div class="loader">
+				<span></span>
+				<span></span>
+				<span></span> -->
+			</div>
 		</div>
-
 	</body>
+
 	<script>
-			var data_dir = document.getElementById('data-dir-input');
-			var source = document.getElementById('source-input');
-			var sample_rate = document.getElementById('sample-rate-input');
-			var stop_button = document.getElementById('stop-button');
-			var start_button = document.getElementById('start-button');
+		var collectorStatus = JSON.parse({{ status|tojson }});
+		var data_dir_element = document.getElementById('data-dir-input');
+		var source_element = document.getElementById('source-input');
+		var sample_rate_element = document.getElementById('sample-rate-input');
+		var collector_status_element = document.getElementById('status-area')
+		var controls = document.getElementById('controls');
+
+		var stop_button = document.getElementById('stop-button');
+		var start_button = document.getElementById('start-button');
+
+		update_form();
 
 		function start() {
-			stop_button.disabled = false;
-			start_button.disabled = true;
-			url = `/start?data_dir=${data_dir.value}&source=${source.value}&sample_rate=${sample_rate.value}`;
-			window.location.href = url
-
+			url = `
+			/start?
+			data_dir=${data_dir_element.value}
+			&source=${source_element.value}
+			&sample_rate=${sample_rate_element.value}`;
+			window.location.href = url;
+			update_form();
 		}
 
 		function stop() {
-			start_button.disabled = false;
-			stop_button.disabled = true;
 			window.location.href = `/stop`
+			update_form();
 		}
+
+		function update_form() {
+			is_running = collectorStatus.is_running	
+			stop_button.disabled = !is_running;
+			stop_button.style.opacity = is_running ? 1 : 0.2;
+			start_button.disabled = is_running;
+			start_button.style.opacity = is_running ? 0.2 : 1;
+			source_element.disabled = is_running;
+			sample_rate_element.disabled = is_running;
+			data_dir_element.disabled = is_running;
+
+			data_dir_element.value = collectorStatus.data_dir;
+			source_element.value =  collectorStatus.source;
+			sample_rate_element.value = collectorStatus.sample_rate;
+		}
+
+		function make_plot(data) {
+			a = 5;
+		}
+
 	</script>
 </html>


### PR DESCRIPTION
MVP of a working web dashboard, with basic controls to start and stop the sensor at a given sample rate.

To start and stop a collection, use the controller box shown below. 'Sample rate' means how long to wait between samples. 'collection name' will map to the name of the subdirectory that the data is saved to. For example: a 'collection name' of `oyster` will save data to `data/oyster`. 
![image](https://user-images.githubusercontent.com/9022917/142792485-fce6206d-2765-40d9-b2ee-6fd770e3ee84.png)

The graph gets its data on page load by hitting the endpoint `/collection`, which uses the current `data_dir` of the global collector object to read data from the right subdirectory. 

The Current Readings box updates every 2 seconds by hitting an endpoint `/current`, which under the hood calls `peripherals.get_sensor_datapoint`. It's possible to update the graph this way as well, but not necessary at this point. 
![image](https://user-images.githubusercontent.com/9022917/142794209-e66edfd1-c2e1-48d7-bf18-bcd476f4128c.png)


Potential Next steps:

- Cloud backup to s3 
- Figure out how to separate environments (on the pi vs local development - different imports. Environment variable?)
- Table view
- Option to download data as csv to client
- Better control of which data to view (select by time start/end?)
- Humidifier control (Relay ON/OFF)
- Webcam!?!?